### PR TITLE
Build SQLite 3.28 on newer BinaryBuilder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: julia
 os:
-- linux
+  - linux
 julia:
-  - 0.7
+  - 1.0
 notifications:
   email: false
 git:
@@ -10,19 +10,25 @@ git:
 cache:
   timeout: 1000
   directories:
-  - downloads
+    - downloads
 env:
   global:
-  - BINARYBUILDER_DOWNLOADS_CACHE=downloads
-  - BINARYBUILDER_AUTOMATIC_APPLE=true
+    - BINARYBUILDER_DOWNLOADS_CACHE=downloads
+    - BINARYBUILDER_AUTOMATIC_APPLE=true
 sudo: required
+
+# Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'using Pkg; Pkg.add([PackageSpec(name="BinaryBuilder", rev="sf/bb8"), PackageSpec(name="BinaryProvider")])'
+  - julia -e 'using Pkg; pkg"add BinaryProvider"; pkg"add BinaryBuilder#master"; Pkg.build()'
+
 script:
-- julia build_tarballs.jl
+  - julia build_tarballs.jl
+
 deploy:
   provider: releases
   api_key:
+    # Note; this api_key is only valid for JuliaDatabases/SQLiteBuilder; you need
+    # to make your own: https://docs.travis-ci.com/user/deployment/releases/
     secure: TImWR+gaJt7ql0+fQG1PhgpQA66L7L8kAz3hcgZu8eIBwWA0dLKw1UUAT5gscHLDoLcj8EwFWMy3qSG7OiHR+NjfzcdHpNs9brZdP3SBmCtDE/Os9/dJgb6FiRlnxSIaCtlD8pSANFNkG0yXKdPf47HwyMsY4Q38EBmbmiDjqEs2gTtra+xkWK6vm7Q1tOHme2VkUt+4bcz/slc1bO45mJVYMS8DHOJympehigYauHdBGadRUF//WxpPzG68ouqh64da0lGkJt3HYLXAU8LMuJ7tOE5AGEnFMlaTpwt0bQIGIhpDX0sSxCCAYuMMn3jLkYdje/wGE+W33XgrlhQt2Fs3Dy79GC/RbvQBBN47VQtl8BSUWGlza8ZBO0NAo8xeWpjK7qAniqrLTgpbX0btRSZRfx/4nx9EioKh1tfJCEcchk3pnECzNx3odm+pKbhLtn21F7qRoLDUDWEv5bGsV5oZU5+WPQu2xjjmWotPaioYOg3EhJvbucZMr93Wtmub4b0RBq9JHH0smny2Z6wFdPPNC6b0N1sVga8m/gtA7TgNnOHNH4Zec6Q7vklfaTtRNnqLEIFzpJnaydshIexR7LSkT0hWUE/e/W8LtBBfefp8Oh7IF82ZcdItQ1oZ7iS+49p7aS6O5PVaec7Qu1jei2jkDEGBLVrz+ImCOF16l3g=
   file_glob: true
   file: products/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# SQLiteBuilder builder
+# SQLiteBuilder
+
+[![Build Status](https://travis-ci.org/JuliaDatabases/SQLiteBuilder.svg?branch=master)](https://travis-ci.org/JuliaDatabases/SQLiteBuilder)
 
 This repository builds binary artifacts for the SQLiteBuilder project.
 This repository has a default .travis.yml file that can be used to build
@@ -8,3 +10,5 @@ upload manually. See https://docs.travis-ci.com/user/deployment/releases/.
 If you don't wish to use travis, you can use the build_tarballs.jl
 file manually and upload the resulting artifacts to a hosting provider
 of your choice.
+
+This repository was created using [BinaryBuilder.jl](https://github.com/JuliaPackaging/BinaryBuilder.jl)

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,21 +3,19 @@
 using BinaryBuilder
 
 name = "SQLiteBuilder"
-version = v"0.1.0"
+version = v"3.28.0"
 
 # Collection of sources required to build SQLiteBuilder
 sources = [
-    "https://www.sqlite.org/2018/sqlite-autoconf-3240000.tar.gz" =>
-    "d9d14e88c6fb6d68de9ca0d1f9797477d82fc3aed613558f87ffbdbbc5ceb74a",
-
+    "https://www.sqlite.org/2019/sqlite-autoconf-3280000.tar.gz" =>
+    "d61b5286f062adfce5125eaf544d495300656908e61fca143517afcc0a89b7c3",
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-cd sqlite-autoconf-3240000/
+cd sqlite-autoconf-3280000/
 ./configure --prefix=$prefix --host=$target && make && make install
-
 """
 
 # These are the platforms we will build for by default, unless further
@@ -30,10 +28,7 @@ products(prefix) = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
-    
-]
+dependencies = []
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -2,10 +2,10 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
-name = "SQLiteBuilder"
+name = "SQLite"
 version = v"3.28.0"
 
-# Collection of sources required to build SQLiteBuilder
+# Collection of sources required to build SQLite
 sources = [
     "https://www.sqlite.org/2019/sqlite-autoconf-3280000.tar.gz" =>
     "d61b5286f062adfce5125eaf544d495300656908e61fca143517afcc0a89b7c3",


### PR DESCRIPTION
Reason I started this PR was to fix this warning:
```
Warning: platform_key() is deprecated, use platform_key_abi() from now on
```

Which comes from the dated [build.jl](https://github.com/JuliaDatabases/SQLiteBuilder/releases/download/v0.9.0/build_SQLiteBuilder.v0.1.0.jl) that the current latest release has. Simply building again on a newer BinaryBuilder will fix that. I come across this in downsteam builders like [PROJBuilder](https://github.com/JuliaGeo/PROJBuilder) that depend on this builder.

But while I was at it I made some more updates, if you prefer I can remove them again:

- Update from SQLite 3.24 to 3.28 ([changes](https://www.sqlite.org/draft/changes.html))
- To be more in line with other builders: change `name` from `SQLiteBuilder` to `SQLite`
- To be more in line with other builders: change `version` from the builder version to the SQLite version. The release tag can then be `v3.28.0-1` with the last part indicating the build number.
- Travis build on julia 1.0, update YAML to how the wizard would print it now

If this is tagged I can make a PR to SQLite.jl to use this build.